### PR TITLE
depreciate default string constructor for Id

### DIFF
--- a/code/com/jivesoftware/os/tasmo/tasmo-event-api/src/main/java/com/jivesoftware/os/tasmo/event/api/JsonEventConventions.java
+++ b/code/com/jivesoftware/os/tasmo/tasmo-event-api/src/main/java/com/jivesoftware/os/tasmo/event/api/JsonEventConventions.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
 import com.jivesoftware.os.jive.utils.logger.MetricLogger;
 import com.jivesoftware.os.jive.utils.logger.MetricLoggerFactory;
 import com.jivesoftware.os.tasmo.id.Id;
@@ -31,6 +32,7 @@ public class JsonEventConventions {
 
     private static final MetricLogger LOG = MetricLoggerFactory.getLogger();
     private static final ObjectMapper mapper = new ObjectMapper();
+    private static final BaseEncoding coder = BaseEncoding.base32().lowerCase().omitPadding();
 
     public JsonEventConventions() {
     }
@@ -84,7 +86,7 @@ public class JsonEventConventions {
             return null;
         }
         try {
-            return new Id(got.textValue());
+            return new Id(coder.decode(getTextValue(got)));
         } catch (Exception ex) {
             LOG.debug("Failed to get instanceId for className '" + className + "': " + eventNode, ex);
             return null;
@@ -159,6 +161,13 @@ public class JsonEventConventions {
         }
     }
 
+    private String getTextValue(JsonNode got) {
+        String gotTextValue = got.textValue();
+        if (gotTextValue == null || gotTextValue.length() == 0) {
+            throw new IllegalArgumentException("stringForm can not be null and must be at least 1 or more chars." + gotTextValue);
+        }
+        return gotTextValue;
+    }
 
     private Id getId(ObjectNode objectNode, String fieldName) {
         JsonNode got = objectNode.get(fieldName);
@@ -166,7 +175,7 @@ public class JsonEventConventions {
             return null;
         }
         try {
-            return new Id(got.textValue());
+            return new Id(coder.decode(getTextValue(got)));
         } catch (Exception ex) {
             LOG.debug("Failed to get objectId for field " + fieldName + ": " + objectNode, ex);
             return null;

--- a/code/com/jivesoftware/os/tasmo/tasmo-id/src/test/java/com/jivesoftware/os/tasmo/id/IdTest.java
+++ b/code/com/jivesoftware/os/tasmo/tasmo-id/src/test/java/com/jivesoftware/os/tasmo/id/IdTest.java
@@ -10,13 +10,18 @@ package com.jivesoftware.os.tasmo.id;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Random;
+
+import com.google.common.io.BaseEncoding;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.FileAssert.fail;
 
 
 public class IdTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final BaseEncoding CODER = BaseEncoding.base32().lowerCase().omitPadding();
 
     @Test
     public void idStringTest() throws Exception {
@@ -61,5 +66,35 @@ public class IdTest {
         String json = "{ \"id\": \"aaaaaaaaaafue\"}";
 
         Assert.assertEquals(MAPPER.readValue(json, Id.class), new Id(2882));
+    }
+
+    @Test
+    public void testStringConstructorReturnsLong() throws Exception {
+        Id stringId = new Id("eight");
+        Assert.assertTrue(isLong(stringId.toStringForm()));
+
+        Id fromStringForm = new Id(stringId.toStringForm());
+        Assert.assertEquals(stringId, fromStringForm);
+    }
+
+    @Test
+    public void mapsFromLegacyObject() throws Exception {
+        Id legacy = new Id("eight", true);
+        String json = "{ \"id\": \"" + legacy.toStringForm() + "\"}";
+        Assert.assertEquals(MAPPER.readValue(json, Id.class), legacy);
+    }
+
+    @Test
+    public void test() {
+        Id numberId = new Id(1);
+        Id stringFormId = new Id(numberId.toStringForm());
+
+        Assert.assertEquals(numberId, stringFormId);
+        Assert.assertEquals(numberId.toStringForm(), stringFormId.toStringForm());
+    }
+
+    private static boolean isLong(String stringForm) {
+        byte [] id = CODER.decode(stringForm);
+        return (id.length == 8);
     }
 }


### PR DESCRIPTION
This change is about moving away from the string constructor for Id, and moving back to using the constructor that takes a long. This should be adequate for current id space concerns.

Here's what this addresses:
      1) Deprecate the String constructor
      2) Change the implementation of this constructor so that it it now converts the string to a bit packed long, basically by doing this:

```
   ByteBuffer buffer = ByteBuffer.wrap(coder.decode(oldStringFormOfId));
    Id id = new Id(buffer.getLong());
```

This will essentially switches us to long representation everywhere, without the massive code change fanout. We can slowly, convert the depreciated constructor calls at our leisure.

3) Change the implementation of idFromJsonObject, so that it is backwards compatible, i.e. if the passed in json string is a bit packed long, we return a new Id constructed with a long. If it's not a bit packed long, we know this is legacy (i.e. existing json on the hdfs WAL) and we make sure we're backwards compatible.

I think this is a reasonable first step, it has a lot of goodness:
- Deprecates the existing constructor
- Seamless converts all users of the string constructor, to long representation
- Maintains backwards compatibility with existing json, created and serialized with the older string constructor
